### PR TITLE
Add hoehendaten.de API integration to QGIS plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,72 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ---
 
+## [6.0.0] - 2025-11-04
+
+### 🚀 Hauptrelease - Hoehendaten.de API Integration & GeoPackage Output
+
+#### Hinzugefügt
+- **Hoehendaten.de API Integration** 🌐
+  - Automatischer DEM-Download von hoehendaten.de API
+  - Deutschland-weite Abdeckung mit 1m Auflösung
+  - Multi-Tile-Support mit automatischem Mosaicking
+  - `fetch_dem_tile_from_api()`: Holt einzelne 1×1km Kacheln
+  - `create_dem_mosaic_from_tiles()`: Erstellt nahtloses Mosaik aus mehreren Tiles
+  - `calculate_tiles_for_radius_points()`: Per-Site Radius-Berechnung (250m um jeden Standort)
+  - Boolean Parameter `USE_HOEHENDATEN_API` zum Umschalten
+  - Fallback auf manuelles DEM bei Offline/API-Fehler
+
+- **Intelligentes DEM-Caching-System** 💾
+  - Persistenter Cache in `~/.qgis3/hoehendaten_cache/tiles/`
+  - LRU (Least Recently Used) Eviction-Strategie
+  - `load_cache_metadata()`: Lädt Cache-Index mit Zugriffszähler und Zeitstempel
+  - `save_cache_metadata()`: Speichert Cache-Index persistent
+  - `cleanup_cache_lru()`: Entfernt am wenigsten genutzte Tiles bei Überschreitung
+  - Max. 100 Tiles (~500MB) automatische Limits
+  - Boolean Parameter `FORCE_DEM_REFRESH` für manuellen Cache-Refresh
+  - Wiederverwendung zwischen QGIS-Sessions
+
+- **GeoPackage All-in-One Output** 📦
+  - Ein einziges .gpkg für alle Outputs (Raster + Vektoren)
+  - `generate_geopackage_path()`: Erstellt Dateinamen aus südwestlichstem Punkt
+  - `save_raster_to_geopackage()`: Speichert DEM-Raster mit gdal:translate
+  - `save_vector_to_geopackage()`: Fügt Vektorlayer hinzu
+  - Automatischer Dateiname: `WKA_{Rechtswert}_{Hochwert}.gpkg`
+  - HTML-Report mit gleichem Basisdateinamen daneben
+  - Speicherung im aktuellen Arbeitsverzeichnis
+  - Enthält: DEM-Raster, Plattformen, Fundamente, Volumen-Daten, Profillinien
+
+- **Umfassender Crash-Schutz** 🛡️
+  - Multi-layered Validierung bei API-Antworten
+  - Base64-Dekodierungs-Fehlerbehandlung
+  - GeoTIFF-Validierung vor GDAL-Operationen
+  - Try-Catch für alle Raster-Layer-Erstellungen
+  - Detailliertes Logging mit ✓/✗/⚠ Indikatoren
+
+#### Geändert
+- Dateiname: `prototype.py` → `WindTurbine_Earthwork_Calculator.py`
+- Version: 5.5 → **6.0**
+- Parameter `INPUT_DEM` jetzt optional (wenn API aktiviert)
+- Output-Parameter entfernt (automatische Generierung)
+- Alle temporären Outputs werden in finale GeoPackage kopiert
+- DEM-Mosaik wird als Layer in GeoPackage integriert
+
+#### Behoben
+- **API-Request-Format**: Korrigierte Header (`Accept-Encoding: gzip`) und Request-Body (`data=json.dumps()` statt `json=`)
+- **QGIS-Crash-Prevention**: Umfangreiche Validierung verhindert Abstürze durch ungültige Raster-Daten
+- **Cache-Konsistenz**: Metadata wird atomar geschrieben, Locking verhindert Race-Conditions
+
+#### Dependencies
+- **NEU**: `requests` library (für API-Kommunikation)
+- Bestehende Dependencies: `numpy`, `qgis.core`, `PyQt5`
+
+#### Rückwärtskompatibilität
+- ✅ Manueller DEM-Upload weiterhin unterstützt (API optional)
+- ✅ Alle v5.5 Features (Polygon-basiert, Geländeschnitte) funktionieren unverändert
+- ✅ Bestehende Parameter-Kombinationen kompatibel
+
+---
+
 ## [5.5.0] - 2025-10-04
 
 ### 🚀 Hauptrelease - Polygon-basierte Berechnungen & Professional Reports

--- a/prototype/INSTALLATION_QGIS.md
+++ b/prototype/INSTALLATION_QGIS.md
@@ -4,29 +4,41 @@
 
 - **QGIS 3.22+** (Python 3.9+)
 - **NumPy** (in QGIS enthalten)
+- **Requests** (für hoehendaten.de API, siehe Installation)
 - **Matplotlib** (optional, für Geländeschnitte)
 
 ---
 
 ## 🚀 Installationsschritte
 
-### 1. Script-Datei kopieren
+### 1. Python-Paket installieren (NEU v6.0)
+
+Installiere die `requests` Bibliothek in QGIS Python:
+
+```python
+# In QGIS Python-Console (Plugins → Python-Konsole)
+import subprocess
+import sys
+subprocess.check_call([sys.executable, "-m", "pip", "install", "requests"])
+```
+
+### 2. Script-Datei kopieren
 
 Kopiere **eine Datei** in den QGIS Processing Scripts Ordner:
 
 ```bash
 # Linux/Mac
-cp prototype/prototype.py ~/.local/share/QGIS/QGIS3/profiles/default/processing/scripts/
+cp prototype/WindTurbine_Earthwork_Calculator.py ~/.local/share/QGIS/QGIS3/profiles/default/processing/scripts/
 
 # Windows (PowerShell)
-Copy-Item prototype\prototype.py -Destination "$env:APPDATA\QGIS\QGIS3\profiles\default\processing\scripts\"
+Copy-Item prototype\WindTurbine_Earthwork_Calculator.py -Destination "$env:APPDATA\QGIS\QGIS3\profiles\default\processing\scripts\"
 ```
 
-**Hinweis:** Ab v5.5 ist der Professional HTML Report direkt integriert - kein externes Modul mehr nötig!
+**Hinweis:** Ab v6.0 mit integrierter API, Caching und GeoPackage-Output!
 
 ---
 
-### 2. QGIS-Scripts neu laden
+### 3. QGIS-Scripts neu laden
 
 #### Option A: Über Menü
 1. QGIS öffnen
@@ -44,7 +56,7 @@ Copy-Item prototype\prototype.py -Destination "$env:APPDATA\QGIS\QGIS3\profiles\
 
 ---
 
-### 3. Tool finden
+### 4. Tool finden
 
 Das Tool erscheint in der **Processing Toolbox** unter:
 
@@ -52,33 +64,41 @@ Das Tool erscheint in der **Processing Toolbox** unter:
 Processing Toolbox
 └── Scripts
     └── Windkraft
-        └── Wind Turbine Earthwork Calculator v5.5
+        └── Wind Turbine Earthwork Calculator v6.0
 ```
 
 ---
 
 ## 🧪 Funktionstest
 
-### Minimaler Test (ohne Geländeschnitte)
+### Minimaler Test mit API (NEU v6.0)
 
 1. **Input vorbereiten:**
-   - DEM (Raster, projiziert, z.B. UTM)
-   - WKA-Standorte (Punkt-Layer, mindestens 1 Punkt)
+   - WKA-Standorte (Punkt-Layer, mindestens 1 Punkt, UTM32N empfohlen)
+   - DEM wird automatisch von hoehendaten.de API geladen
+   - Optional: Eigenes DEM (Raster, projiziert, z.B. UTM)
 
 2. **Tool öffnen:**
-   - Processing Toolbox → Windkraft → "Wind Turbine Earthwork Calculator v5.5"
+   - Processing Toolbox → Windkraft → "Wind Turbine Earthwork Calculator v6.0"
 
 3. **Parameter einstellen:**
-   - INPUT DEM: Dein Raster
-   - INPUT Points: Dein Punkt-Layer
-   - OUTPUT Report: Pfad zur HTML-Datei (z.B. `~/test_report.html`)
+   - ✓ DEM von hoehendaten.de API beziehen: Aktiviert (NEU!)
+   - INPUT Points: Dein Punkt-Layer (UTM32N)
+   - INPUT DEM: Leer lassen (API lädt automatisch)
    - Alle anderen Parameter: Default-Werte OK
 
 4. **Ausführen:**
    - "Run" klicken
+   - Beobachten Sie die API-Downloads im Log
+   - Cache wird in ~/.qgis3/hoehendaten_cache/ gespeichert
    - Warten bis "✅ Fertig!" erscheint
 
-5. **Report öffnen:**
+5. **Ergebnisse:**
+   - GeoPackage im aktuellen Verzeichnis: `WKA_{X}_{Y}.gpkg`
+   - HTML-Report: `WKA_{X}_{Y}.html`
+   - GeoPackage enthält DEM + alle Vektorlayer
+
+6. **Report öffnen:**
    - HTML-Datei im Browser öffnen
    - "📄 Als PDF exportieren" Button testen (oben rechts)
 
@@ -210,6 +230,6 @@ processing.algorithmHelp("script:windturbineearthworkv3")
 
 ---
 
-**Version:** 5.5 (Polygon-based Sampling + Professional Report)  
-**Autor:** Windkraft-Standortplanung  
-**Datum:** Oktober 2025
+**Version:** 6.0 (Hoehendaten.de API Integration & GeoPackage Output)
+**Autor:** Windkraft-Standortplanung
+**Datum:** November 2025

--- a/prototype/WORKFLOW_STANDFLAECHEN.md
+++ b/prototype/WORKFLOW_STANDFLAECHEN.md
@@ -1,8 +1,10 @@
 # Workflow: Standflächen-basierte WKA-Planung
 
+**Hinweis**: Dieser Workflow gilt unverändert für v6.0. Die neuen Features (API-Integration, Caching, GeoPackage-Output) ergänzen diesen Workflow, ändern ihn aber nicht.
+
 ## Übersicht
 
-Der Wind Turbine Earthwork Calculator v3.0 unterstützt einen **2-Schritt-Workflow** für die präzise Platzierung von Windkraftanlagen-Standflächen:
+Der Wind Turbine Earthwork Calculator unterstützt einen **2-Schritt-Workflow** für die präzise Platzierung von Windkraftanlagen-Standflächen:
 
 1. **Schritt 1**: Automatische Generierung von Standflächen-Polygonen basierend auf Punkt-Koordinaten
 2. **Schritt 2**: Manuelle Anpassung der Polygone und Neuberechnung (geplant für v4.0)

--- a/prototype/WindTurbine_Earthwork_Calculator.py
+++ b/prototype/WindTurbine_Earthwork_Calculator.py
@@ -1,14 +1,15 @@
 """
-Wind Turbine Earthwork Calculator - Version 5.6
+Wind Turbine Earthwork Calculator - Version 6.0
 ================================================
 
-NEUE FEATURES v5.6 (hoehendaten.de API Integration):
-- Automatischer DEM-Download von hoehendaten.de API
-- Keine manuelle DEM-Datei mehr nötig (optional)
-- Multi-Kachel-Support mit automatischem Mosaik
-- Deutschland-weite Abdeckung (1m-Auflösung)
-- Intelligente Bounding-Box-Berechnung aus WKA-Standorten
-- Automatische UTM-Zonen-Erkennung
+NEUE FEATURES v6.0 (hoehendaten.de API Integration & GeoPackage Output):
+- 🌐 Automatischer DEM-Download von hoehendaten.de API
+- 💾 DEM-Cache mit LRU-Strategie (persistent, max 100 Kacheln ~500MB)
+- 📍 Standort-basierte Kachel-Berechnung (250m Radius pro Standort)
+- 🔄 Manuelle Cache-Aktualisierung (Force-Refresh Parameter)
+- 📦 Ein GeoPackage für alle Outputs (DEM + Vektoren)
+- 🗂️ Automatischer Dateiname aus südwestlichstem Punkt
+- 📄 HTML-Report neben GeoPackage
 
 FEATURES v5.5 (Polygon Refactoring):
 - Beliebige Polygon-Formen für Kranstellflächen (L, Trapez, Kreis, Freiform)

--- a/prototype/installationsanleitung.md
+++ b/prototype/installationsanleitung.md
@@ -1,13 +1,14 @@
 # 🚀 SCHRITT-FÜR-SCHRITT ANLEITUNG
-## Wind Turbine Earthwork Calculator - Prototyp Installation
+## Wind Turbine Earthwork Calculator v6.0 - Installation
 
 ---
 
 ## ✅ VORAUSSETZUNGEN
 
 Was Sie brauchen:
-- ✓ QGIS installiert (Version 3.x)
-- ✓ Internet-Verbindung
+- ✓ QGIS installiert (Version 3.0 oder höher)
+- ✓ Internet-Verbindung (für API-Nutzung)
+- ✓ Python `requests` Bibliothek (Installation siehe unten)
 - ✓ Etwa 30 Minuten Zeit
 
 ---
@@ -67,35 +68,53 @@ Ich erstelle Ihnen gleich ein Python-Skript, das Test-DEM-Daten für Sie generie
 
 ---
 
-## 💾 SCHRITT 3: SCRIPT SPEICHERN
+## 📦 SCHRITT 3: PYTHON-PAKET INSTALLIEREN (NEU v6.0)
 
-**3.1** Den Python-Code kopieren:
-- Öffnen Sie das Artifact "Wind Turbine Earthwork Calculator - QGIS Processing Script" (oben)
-- Markieren Sie den **gesamten Code** (Strg+A)
-- Kopieren Sie ihn (Strg+C)
+**3.1** QGIS öffnen
 
-**3.2** Code in Datei speichern:
-1. Öffnen Sie einen Texteditor (Notepad, Notepad++, oder ähnlich)
-2. Fügen Sie den Code ein (Strg+V)
-3. Speichern unter:
-   - Speicherort: `C:\GIS_Daten\Windkraft\Scripts\`
-   - Dateiname: `wind_earthwork_calculator.py`
-   - **WICHTIG:** Dateityp: "Alle Dateien (*.*)" auswählen
-   - **NICHT** als .txt speichern!
+**3.2** Python Console öffnen:
+- Menü: `Plugins` → `Python-Konsole`
+- Oder Tastenkombination: `Strg+Alt+P`
 
-**3.3** Überprüfung:
-- Die Datei muss heißen: `wind_earthwork_calculator.py`
-- Dateigröße sollte ca. 20-25 KB sein
+**3.3** Requests-Bibliothek installieren:
+```python
+import subprocess
+import sys
+subprocess.check_call([sys.executable, "-m", "pip", "install", "requests"])
+```
+
+**3.4** Warten bis Installation abgeschlossen
+- Sie sollten sehen: "Successfully installed requests-..."
+- Falls Fehler: QGIS als Administrator starten und erneut versuchen
 
 ---
 
-## 🔧 SCHRITT 4: TEST-DEM ERSTELLEN (OPTIONAL, ABER EMPFOHLEN)
+## 💾 SCHRITT 4: SCRIPT SPEICHERN
 
-Wenn Sie noch keine echten DEM-Daten haben, erstellen wir jetzt welche:
+**4.1** Den Python-Code kopieren:
+- Laden Sie `WindTurbine_Earthwork_Calculator.py` herunter
+- Oder kopieren Sie das Script aus dem Repository
 
-**4.1** QGIS öffnen
+**4.2** Code in QGIS Scripts-Ordner speichern:
+   - **Linux/Mac**: `~/.local/share/QGIS/QGIS3/profiles/default/processing/scripts/`
+   - **Windows**: `%APPDATA%\QGIS\QGIS3\profiles\default\processing\scripts\`
 
-**4.2** Python Console öffnen:
+**4.3** Überprüfung:
+- Die Datei muss heißen: `WindTurbine_Earthwork_Calculator.py`
+- Dateigröße sollte ca. 150-200 KB sein
+
+---
+
+## 🔧 SCHRITT 5: TEST-DEM ERSTELLEN (OPTIONAL - v6.0 kann API nutzen!)
+
+**NEU in v6.0**: Sie können das DEM auch automatisch von hoehendaten.de beziehen!
+Dieser Schritt ist optional, wenn Sie die API-Integration nutzen möchten.
+
+Wenn Sie lieber mit lokalen Test-Daten arbeiten:
+
+**5.1** QGIS öffnen (falls noch nicht offen)
+
+**5.2** Python Console nutzen (bereits offen von Schritt 3):
 - Menü: `Plugins` → `Python-Konsole`
 - Oder Tastenkombination: `Strg+Alt+P`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,14 @@
 numpy>=1.20.0          # Array-Operationen für DEM-Verarbeitung
                        # In QGIS: meist vorinstalliert
 
+# ===== API Dependencies (NEU v6.0) =====
+# Benötigt für hoehendaten.de API Integration
+
+requests>=2.28.0       # HTTP-Client für API-Kommunikation
+                       # MUSS in QGIS installiert werden:
+                       # import subprocess, sys
+                       # subprocess.check_call([sys.executable, "-m", "pip", "install", "requests"])
+
 # ===== QGIS & PyQt (NUR für Standalone-Testing) =====
 # Diese werden NUR benötigt, wenn du das Script außerhalb
 # von QGIS testen möchtest (sehr selten)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds optional hoehendaten.de DEM fetching with LRU-cached tiles and auto-mosaicking, and consolidates outputs into a single GeoPackage; docs and dependencies updated.
> 
> - **Algorithm (`prototype/WindTurbine_Earthwork_Calculator.py`)**:
>   - **DEM API Integration (v6.0)**: `fetch_dem_tile_from_api()`, per-site tile selection, Base64 decode, GDAL merge; new params `USE_HOEHENDATEN_API`, `FORCE_DEM_REFRESH`; `INPUT_DEM` now optional.
>   - **Caching**: Persistent LRU cache under `~/.qgis3/hoehendaten_cache/tiles/` with metadata, access tracking, and cleanup.
>   - **GeoPackage Output**: Auto path via `generate_geopackage_path()`; saves DEM (`save_raster_to_geopackage`) and vectors into one `WKA_{X}_{Y}.gpkg`; HTML report written alongside.
>   - **Robustness**: Extensive validation/logging for API responses, Base64 decoding, GeoTIFFs, and raster layer loading.
>   - **UI/Help**: Updated display/help text and processing flow to support API mode.
> - **Docs**:
>   - Update `AGENTS.md`, `README.md`, `prototype/INSTALLATION_QGIS.md`, `prototype/installationsanleitung.md`, `prototype/WORKFLOW_STANDFLAECHEN.md` for v6.0 features (API, cache, GPKG) and installation of `requests`.
>   - Add detailed changelog entry `CHANGELOG.md` for 6.0.0.
> - **Dependencies**:
>   - Add `requests` (API) and update `requirements.txt` with dev/test tooling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fbf8ad0c2ffd34ad8f9d2ed3b823e051311c0f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->