### PR TITLE
fix: Add healthcheck and database initialization for auth service

### DIFF
--- a/webapp/docker-compose.yml
+++ b/webapp/docker-compose.yml
@@ -84,6 +84,12 @@ services:
     volumes:
       - ./services/auth_service:/app
     command: uvicorn app.main:app --host 0.0.0.0 --port 8001 --reload
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   # DEM Service (Port 8002)
   dem_service:

--- a/webapp/services/auth_service/Dockerfile
+++ b/webapp/services/auth_service/Dockerfile
@@ -2,7 +2,12 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# Install dependencies
+# Install system dependencies (curl for healthcheck)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 

--- a/webapp/services/auth_service/app/db/init_db.py
+++ b/webapp/services/auth_service/app/db/init_db.py
@@ -1,0 +1,30 @@
+"""
+Initialize database tables
+"""
+import logging
+from sqlalchemy.exc import OperationalError
+from app.db.database import engine, Base
+from app.models import user  # Import models to register them
+
+logger = logging.getLogger(__name__)
+
+
+def init_db():
+    """
+    Create all database tables if they don't exist
+    """
+    try:
+        logger.info("Creating database tables...")
+        Base.metadata.create_all(bind=engine)
+        logger.info("Database tables created successfully")
+    except OperationalError as e:
+        logger.error(f"Failed to create database tables: {e}")
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error during database initialization: {e}")
+        raise
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    init_db()

--- a/webapp/services/auth_service/app/main.py
+++ b/webapp/services/auth_service/app/main.py
@@ -2,11 +2,14 @@
 Auth Service - Main Application
 FastAPI app for authentication (Magic Links + JWT)
 """
+import logging
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import get_settings
 from app.api import auth
+from app.db.init_db import init_db
 
+logger = logging.getLogger(__name__)
 settings = get_settings()
 
 # Create app
@@ -17,6 +20,18 @@ app = FastAPI(
     docs_url="/docs",
     redoc_url="/redoc"
 )
+
+
+@app.on_event("startup")
+async def startup_event():
+    """Initialize database on startup"""
+    try:
+        logger.info("Starting up auth service...")
+        init_db()
+        logger.info("Auth service started successfully")
+    except Exception as e:
+        logger.error(f"Failed to start auth service: {e}")
+        raise
 
 # CORS middleware
 app.add_middleware(


### PR DESCRIPTION
This commit adds several improvements to ensure the auth service starts reliably:

1. Added healthcheck to docker-compose.yml for auth_service container
   - Uses curl to check /health endpoint
   - 30s start period to allow for initialization
   - 5 retries with 10s interval

2. Updated Dockerfile to install curl for healthcheck support

3. Added database initialization on startup
   - New init_db.py module to create tables automatically
   - Startup event handler in main.py to run init_db()
   - Ensures tables are created with correct schema (user_metadata)

This resolves the "Container is unhealthy" error by ensuring the service properly initializes and responds to health checks.