### PR TITLE
erste bugfixes

### DIFF
--- a/webapp/docker-compose.yml
+++ b/webapp/docker-compose.yml
@@ -130,6 +130,7 @@ services:
     environment:
       REDIS_URL: redis://redis:6379
       DEM_SERVICE_URL: http://dem_service:8002
+      PYTHONPATH: /shared
     depends_on:
       redis:
         condition: service_healthy
@@ -150,6 +151,7 @@ services:
       - "8004:8004"
     environment:
       REDIS_URL: redis://redis:6379
+      PYTHONPATH: /shared
     depends_on:
       redis:
         condition: service_healthy

--- a/webapp/services/calculation_service/app/api/calculation.py
+++ b/webapp/services/calculation_service/app/api/calculation.py
@@ -13,9 +13,7 @@ from app.schemas.calculation import (
     WKASiteRequest, WKASiteResponse
 )
 
-# Import shared modules
-import sys
-sys.path.append('/shared')
+# Import shared modules (PYTHONPATH is set in docker-compose.yml)
 from shared.core.foundation import calculate_foundation_circular, calculate_foundation_polygon
 from shared.core.material_balance import calculate_material_balance
 

--- a/webapp/services/cost_service/app/api/cost.py
+++ b/webapp/services/cost_service/app/api/cost.py
@@ -10,9 +10,7 @@ from app.schemas.cost import (
     CostRatesPreset
 )
 
-# Import shared modules
-import sys
-sys.path.append('/shared')
+# Import shared modules (PYTHONPATH is set in docker-compose.yml)
 from shared.core.material_balance import calculate_material_balance
 from shared.core.costs import calculate_costs
 


### PR DESCRIPTION
Problem:
- cost_service and calculation_service failed to start with ModuleNotFoundError
- Browser console showed 503 errors for /costs/presets endpoint
- Services couldn't import shared modules despite volume mounting

Root Cause:
- sys.path.append('/shared') approach wasn't working reliably
- Python couldn't find the shared module in the import path

Solution:
- Set PYTHONPATH=/shared in docker-compose.yml for both services
- Remove manual sys.path.append calls from code
- Use proper Python environment variable for module resolution

Changes:
- docker-compose.yml: Add PYTHONPATH env var to cost_service and calculation_service
- cost_service/app/api/cost.py: Remove sys.path.append, rely on PYTHONPATH
- calculation_service/app/api/calculation.py: Remove sys.path.append, rely on PYTHONPATH

This ensures the shared modules are properly discoverable at runtime.