### PR TITLE
revert(parallel): re-enable multiprocessing on Linux/macOS after DEM fix

### DIFF
--- a/windturbine_earthwork_calculator_v2/core/multi_surface_calculator.py
+++ b/windturbine_earthwork_calculator_v2/core/multi_surface_calculator.py
@@ -78,41 +78,56 @@ def _get_safe_max_workers(requested_workers: Optional[int] = None) -> int:
     """
     Get safe number of workers for multiprocessing in QGIS context.
 
-    Multiprocessing is currently disabled on **all** platforms when running
-    inside QGIS. Reason:
+    History:
 
-    - **Windows**: spawning a new Python process re-launches QGIS itself,
-      which is unusable.
-    - **Linux/macOS**: Even with the 'spawn' start method, worker processes
-      cannot import numpy correctly when launched from QGIS' bundled Python.
-      The error is 'numpy.core.multiarray failed to import', which makes
-      every DEM sampling call return empty arrays. The resulting workflow
-      reports 'WORKFLOW ERFOLGREICH ABGESCHLOSSEN' but Cut/Fill are 0 m³
-      and the terrain-intersection rasters fail. We tried forcing the
-      'spawn' start method - the message appears in the log, but the
-      numpy import in the worker still fails. The root cause is a
-      PYTHONPATH/site-packages mismatch between QGIS' main process and
-      the spawned children that 'spawn' alone cannot resolve.
+    - Before dc778d9 (Plan B): parallel on Linux/macOS with
+      ``cpu_count() - 1`` workers, single-worker on Windows.
+    - dc778d9 (Plan B): disabled on all platforms after a run showed
+      hundreds of ``numpy.core.multiarray failed to import`` errors and
+      Cut/Fill = 0 m³. Plan B diagnosed the symptom correctly but blamed
+      the wrong component: the numpy error was coming from GDAL's
+      ``_gdal_array`` extension in every ``band.ReadAsArray()`` call, not
+      from the multiprocessing start method. Plan B's sequential fallback
+      hit the exact same error in the main thread - the committed
+      ``windturbine_calculator_20260409.log`` proves it.
+    - This commit: after PR #48 routed all raster IO through
+      ``utils.gdal_compat`` (``ReadRaster`` + ``np.frombuffer``, no
+      ``_gdal_array``), there is no reason to keep the sequential
+      fallback on Linux/macOS. Workers read rasters through the same
+      code path as the main thread and the numpy binding is never
+      touched. Restore the ~7x speedup from the pre-dc778d9 behaviour.
 
-    Sequential execution is slower but produces correct results, which is
-    what matters. If the upstream numpy/QGIS situation changes in a future
-    version, this fallback can be relaxed.
+    On Windows we still return 1 worker because ``ProcessPoolExecutor``
+    there re-launches the QGIS executable for every worker, which is a
+    separate and still-unresolved QGIS compatibility issue.
 
     Args:
-        requested_workers: Requested number of workers (kept for API
-            compatibility, but currently ignored).
+        requested_workers: Requested number of workers (``None`` =
+            auto-detect, use ``cpu_count() - 1``).
 
     Returns:
-        Always 1 (sequential execution).
+        Safe number of workers: 1 on Windows, ``max(1, cpu_count() - 1)``
+        or ``requested_workers`` on Linux/macOS.
     """
     logger = get_plugin_logger()
-    logger.warning(
-        "Multiprocessing disabled inside QGIS (all platforms): worker "
-        "processes cannot reliably import numpy from QGIS' bundled Python "
-        "environment. Calculations will run sequentially - slower, but "
-        "produces correct Cut/Fill volumes."
-    )
-    return 1
+
+    if platform.system() == 'Windows':
+        logger.warning(
+            "Multiprocessing disabled on Windows: ProcessPoolExecutor "
+            "re-launches the QGIS executable for every worker. "
+            "Calculations will run sequentially (slower but stable)."
+        )
+        return 1
+
+    # Linux/macOS: parallel execution.
+    # The 2026-04-09 regression (Cut/Fill = 0) was caused by GDAL's
+    # _gdal_array numpy extension, not by multiprocessing itself.
+    # Once utils.gdal_compat replaced band.ReadAsArray() with
+    # band.ReadRaster() + np.frombuffer(), workers no longer hit the
+    # "numpy.core.multiarray failed to import" error.
+    if requested_workers is None:
+        return max(1, mp.cpu_count() - 1)
+    return max(1, requested_workers)
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Rolls back the behavioural part of `dc778d9` ("Plan B: disable multiprocessing on all platforms") now that #48 has routed all raster IO through `utils.gdal_compat`. On Linux/macOS the coarse search is back to `cpu_count() - 1` workers — roughly the **~7× speedup** from the pre-`dc778d9` behaviour.

**Depends on #48** (already merged). Without the `gdal_compat` helpers, workers would still hit `numpy.core.multiarray failed to import` in `band.ReadAsArray()` and the whole reason for Plan B would come back. #48 is the prerequisite.

## Why Plan B can go

Plan B was a misdiagnosis. The 2026-04-09 regression (Cut/Fill = 0 m³ across every scenario) came from GDAL's `_gdal_array` Python extension failing to import `numpy`, **not** from the multiprocessing start method:

| Symptom | Plan B's theory | Actual root cause |
|---|---|---|
| `numpy.core.multiarray failed to import` in workers | fork/spawn start method | GDAL's `_gdal_array` binding can't resolve numpy |
| Same error in the main thread after `max_workers=1` | — | same `_gdal_array` issue, same code path |
| Terrain-intersection rasters (5 different calls) failing | — | also `band.ReadAsArray()` → `_gdal_array` |

PR #48 replaced every `band.ReadAsArray()` / `band.WriteArray()` with `read_band_as_array()` / `write_array_to_band()` from `utils/gdal_compat.py`, which go through the SWIG `ReadRaster`/`WriteRaster` API + `np.frombuffer`. That path **never touches `_gdal_array`**. Workers and the main thread now use the same code path and neither touches the broken numpy bridge, so there is no reason to keep the sequential fallback on Linux/macOS.

## What this PR changes

One file: `windturbine_earthwork_calculator_v2/core/multi_surface_calculator.py`, function `_get_safe_max_workers`:

```python
# Before (Plan B):
def _get_safe_max_workers(requested_workers=None):
    # ... long docstring about numpy...
    return 1   # always sequential

# After:
def _get_safe_max_workers(requested_workers=None):
    if platform.system() == 'Windows':
        return 1   # ProcessPoolExecutor re-launches QGIS, QGIS-side bug
    # Linux/macOS: parallel
    if requested_workers is None:
        return max(1, mp.cpu_count() - 1)
    return max(1, requested_workers)
```

Windows stays on 1 worker. The Windows issue is separate and orthogonal: `ProcessPoolExecutor` there re-launches the QGIS executable for every worker process, which is a QGIS compatibility problem that the plugin cannot solve on its own.

## What does NOT change

- **No API changes.** `MultiSurfaceCalculator.find_optimum(use_parallel=True/False, max_workers=...)` signature is identical. `workflow_runner.py` is untouched.
- **No math changes.** The downstream two-stage optimisation in `_find_optimum_multi_parameter` already had working `if use_parallel_{coarse,fine}: ... else: ...` branches for both execution paths — they were being chosen based on `use_parallel = max_workers > 1 and num_scenarios >= 20`. That decision logic is unchanged; only the value of `max_workers` changes on Linux/macOS.
- **No new dependencies.** `multiprocessing.ProcessPoolExecutor` and `functools.partial` were already being imported for the existing parallel path.

## Expected impact

For the test dataset in `windturbine_calculator_20260409.log` (4 DXF surfaces, 360 coarse scenarios + 135 fine scenarios on an 8-core Linux build):

| Stage | Before (Plan B, sequential) | After (parallel, 7 workers) |
|---|---|---|
| STAGE 1 COARSE (360 scenarios) | ~200s | ~30s |
| STAGE 2 FINE (135 scenarios) | ~75s | ~15s |
| **Total optimisation** | **~275s** | **~45s** |

Both paths produce the same cut/fill numbers — the regression tests added in #48 (`tests/test_volume_regression.py`) guard the math against any drift in either path, because they exercise the underlying pixel-wise accumulation independent of which executor runs it.

## Test plan

- [x] `python3 -m py_compile windturbine_earthwork_calculator_v2/core/multi_surface_calculator.py`
- [x] Single-commit diff — easy to review, easy to revert
- [x] Rebased cleanly onto `main` after #48 landed
- [ ] **Manual QGIS verification on the affected Linux build**: same testdataset as #48. Expected:
  - `STAGE 1 (COARSE): Parallel mode with 7 workers (360 scenarios)` in the log (not `Sequential mode`)
  - Final `Cut ≈ 7239 m³`, `Fill ≈ 2649 m³`, optimal crane height `≈ 319.87 m ü.NN` (same as reference report)
  - Stage 1 duration substantially shorter than the ~3.5 min observed in the previous Plan-B run
  - No `numpy.core.multiarray failed to import` warnings
- [ ] Cross-check on Windows: unchanged — still sequential, still correct.

## Rollback

If anything unexpected pops up, reverting this PR alone restores the Plan-B sequential fallback without affecting the `gdal_compat` fix from #48. The two PRs are independent and can be rolled back independently.